### PR TITLE
Fixed typehinting of password parameter 

### DIFF
--- a/PhpAmqpLib/Connection/AMQPSSLConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSSLConnection.php
@@ -7,7 +7,7 @@ class AMQPSSLConnection extends AMQPStreamConnection
      * @param AbstractConnection $host
      * @param int $port
      * @param string $user
-     * @param bool $password
+     * @param string $password
      * @param string $vhost
      * @param array $ssl_options
      * @param array $options

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -9,7 +9,7 @@ class AMQPSocketConnection extends AbstractConnection
      * @param AbstractConnection $host
      * @param int $port
      * @param string $user
-     * @param bool $password
+     * @param string $password
      * @param string $vhost
      * @param bool $insist
      * @param string $login_method

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -9,7 +9,7 @@ class AMQPStreamConnection extends AbstractConnection
      * @param AbstractConnection $host
      * @param string $port
      * @param string $user
-     * @param bool $password
+     * @param string $password
      * @param string $vhost
      * @param bool $insist
      * @param string $login_method


### PR DESCRIPTION
Fixed typehinting of password parameter for Connection concrete classes. Was set to bool, refactored to string.
